### PR TITLE
Set the response jobRunID to the request ID

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -30,6 +30,7 @@ type Opts struct {
 // Result represents a Chainlink JobRun
 type Result struct {
 	JobRunID string      `json:"jobRunId"`
+	ID string `json:"id"`
 	Status   string      `json:"status"`
 	Error    null.String `json:"error"`
 	Pending  bool        `json:"pending"`
@@ -90,6 +91,11 @@ func (r *Result) SetErrored(err error) {
 // SetCompleted marks a result as completed
 func (r *Result) SetCompleted() {
 	r.Status = "completed"
+}
+
+// SetJobRunID sets the request's ID to the result's Job Run ID
+func (r *Result) SetJobRunID() {
+	r.JobRunID = r.ID
 }
 
 // Bridge is the interface that can be implemented for custom Chainlink bridges
@@ -200,6 +206,8 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 		rt.SetErrored(err)
 		return
 	}
+
+	rt.SetJobRunID()
 
 	if b, ok := s.pathMap[r.URL.Path]; !ok {
 		cc <- http.StatusBadRequest

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -96,7 +96,7 @@ func (r *Result) SetCompleted() {
 // SetJobRunID sets the request's ID to the result's Job Run ID.
 // If "jobRunId" is supplied in the request, use that for the response.
 func (r *Result) SetJobRunID() {
-	if r.JobRunID == "" {
+	if len(r.JobRunID) == 0 {
 		r.JobRunID = r.ID
 	}
 }

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -30,7 +30,7 @@ type Opts struct {
 // Result represents a Chainlink JobRun
 type Result struct {
 	JobRunID string      `json:"jobRunId"`
-	ID string `json:"id"`
+	ID       string      `json:"id"`
 	Status   string      `json:"status"`
 	Error    null.String `json:"error"`
 	Pending  bool        `json:"pending"`
@@ -93,9 +93,12 @@ func (r *Result) SetCompleted() {
 	r.Status = "completed"
 }
 
-// SetJobRunID sets the request's ID to the result's Job Run ID
+// SetJobRunID sets the request's ID to the result's Job Run ID.
+// If "jobRunId" is supplied in the request, use that for the response.
 func (r *Result) SetJobRunID() {
-	r.JobRunID = r.ID
+	if r.JobRunID == "" {
+		r.JobRunID = r.ID
+	}
 }
 
 // Bridge is the interface that can be implemented for custom Chainlink bridges

--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -33,8 +33,8 @@ func (cc *CryptoCompare) Opts() *Opts {
 
 func TestParseInterface_Map(t *testing.T) {
 	p := map[string]interface{}{
-			"alice": "bob",
-			"carl": "dennis",
+		"alice": "bob",
+		"carl":  "dennis",
 	}
 	json, err := ParseInterface(&p)
 	assert.Nil(t, err)
@@ -50,8 +50,7 @@ func TestParseInterface_String(t *testing.T) {
 	assert.Equal(t, "hello world", json.String())
 }
 
-
-type HelloWorld struct {}
+type HelloWorld struct{}
 
 func (tb *HelloWorld) Run(h *Helper) (interface{}, error) {
 	return `{ "key": "hello world" }`, nil
@@ -68,7 +67,7 @@ func TestNewServer_HelloWorld(t *testing.T) {
 	assert.Equal(t, b, s.pathMap["/"])
 }
 
-type LambdaPath struct {}
+type LambdaPath struct{}
 
 func (tb *LambdaPath) Run(h *Helper) (interface{}, error) {
 	return `{ "key": "hello world" }`, nil
@@ -77,7 +76,7 @@ func (tb *LambdaPath) Run(h *Helper) (interface{}, error) {
 func (tb *LambdaPath) Opts() *Opts {
 	return &Opts{
 		Lambda: true,
-		Path: "/path",
+		Path:   "/path",
 	}
 }
 
@@ -99,7 +98,7 @@ func TestServer_Mux(t *testing.T) {
 	mux := NewServer(b).Mux()
 
 	p := map[string]interface{}{
-		"jobRunId": "1234",
+		"id": "1234",
 	}
 	pb, err := json.Marshal(p)
 	assert.Nil(t, err)
@@ -147,7 +146,7 @@ func TestServer_Mux_BadPath(t *testing.T) {
 	mux := NewServer(b).Mux()
 
 	p := map[string]interface{}{
-		"jobRunId": "1234",
+		"id": "1234",
 	}
 	pb, err := json.Marshal(p)
 	assert.Nil(t, err)
@@ -184,7 +183,7 @@ func TestServer_Mux_BadMethod(t *testing.T) {
 	assert.Equal(t, "errored", json.Get("status").String())
 }
 
-type ReturnError struct {}
+type ReturnError struct{}
 
 func (re *ReturnError) Run(h *Helper) (interface{}, error) {
 	return `{}`, errors.New("error")
@@ -199,7 +198,7 @@ func TestServer_Mux_ReturnError(t *testing.T) {
 	mux := NewServer(b).Mux()
 
 	p := map[string]interface{}{
-		"jobRunId": "1234",
+		"id": "1234",
 	}
 	pb, err := json.Marshal(p)
 	assert.Nil(t, err)
@@ -223,7 +222,7 @@ func TestServer_Mux_CryptoCompare(t *testing.T) {
 	mux := NewServer(&CryptoCompare{}).Mux()
 
 	p := map[string]interface{}{
-		"jobRunId": "1234",
+		"id": "1234",
 	}
 	pb, err := json.Marshal(p)
 	assert.Nil(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -78,7 +78,7 @@ func TestNewJSONBridges_Errors(t *testing.T) {
 
 func TestHandler(t *testing.T) {
 	p := map[string]interface{}{
-		"jobRunId": "1234",
+		"id": "1234",
 	}
 	pb, err := json.Marshal(p)
 	assert.Nil(t, err)
@@ -112,7 +112,7 @@ func TestHandler(t *testing.T) {
 
 func TestHandler_NilBridge(t *testing.T) {
 	p := map[string]interface{}{
-		"jobRunId": "1234",
+		"id": "1234",
 	}
 	pb, err := json.Marshal(p)
 	assert.Nil(t, err)
@@ -135,7 +135,7 @@ func TestHandler_NilBridge(t *testing.T) {
 
 func TestHandler_InvalidBridge(t *testing.T) {
 	p := map[string]interface{}{
-		"jobRunId": "1234",
+		"id": "1234",
 	}
 	pb, err := json.Marshal(p)
 	assert.Nil(t, err)


### PR DESCRIPTION
External adapters receive a payload like the following, where params can be in the `data` object:
```
{"id":"278c97ffadb54a5bbb93cfec5f7b5503","data":{}}
```
Bridges should now respond with the request's `id` as its `jobRunId` in response.