### PR TITLE
Update build instructions for AWS Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ After you've completed implementing your bridge, you can then test it in AWS Lam
 
 1. Build the executable:
     ```bash
-    GO111MODULE=on go build -o bridge
+    GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o bridge
     ```
 2. Add the file to a ZIP archive:
     ```bash


### PR DESCRIPTION
To build for AWS Lambda, correct OS and Arch needs to be defined.

This PR sets the required env vars required to build in the AWS Lambda instructions.